### PR TITLE
chore: correct synth input data

### DIFF
--- a/json-file/1-Synth/1-Synth.json
+++ b/json-file/1-Synth/1-Synth.json
@@ -93,20 +93,7 @@
                         "sampleID": "123",
                         "role": "solvent",
                         "internalBarCode": "1",
-                        "measuredQuantity": {
-                            "value": "",
-                            "unit": "mg",
-                            "errorMargin": {
-                                "value": 0.01,
-                                "unit": "mg"
-                            }
-                        },
                         "physicalState": "Liquid",
-                        "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
-                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "134",
                             "chemicalName": "Toluene",
@@ -191,7 +178,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "1",
+                            "value": 1,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.001,
@@ -199,11 +186,6 @@
                             }
                         },
                         "physicalState": "Liquid",
-                        "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
-                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "134",
                             "chemicalName": "4-methoxybenzaldehyde",
@@ -288,7 +270,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "1",
+                            "value": 1,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.01,
@@ -296,11 +278,6 @@
                             }
                         },
                         "physicalState": "Liquid",
-                        "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
-                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "135",
                             "chemicalName": "Styrene",
@@ -385,7 +362,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "5",
+                            "value": 5,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.1,
@@ -393,11 +370,6 @@
                             }
                         },
                         "physicalState": "Liquid",
-                        "concentration": {
-                            "value": "",
-                            "unit": "mol/L"
-                        },
-                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "137",
                             "chemicalName": "4-(Difluoromethyl)benzyl bromide",
@@ -409,11 +381,7 @@
                             "smiles": "BrCc1ccc(cc1)C(F)(F)F",
                             "swissCatNumber": "",
                             "Inchi": "1S/C8H7BrF2/c9-5-6-1-3-7(4-2-6)8(10)11/h1-4,8H,5H2",
-                            "molecularFormula": "C8H7BrF2",
-                            "density": {
-                                "value": "",
-                                "unit": "g/mL"
-                            }
+                            "molecularFormula": "C8H7BrF2"
                         }
                     }
                 ]

--- a/json-file/1-Synth/1-Synth.json
+++ b/json-file/1-Synth/1-Synth.json
@@ -93,7 +93,20 @@
                         "sampleID": "123",
                         "role": "solvent",
                         "internalBarCode": "1",
+                        "measuredQuantity": {
+                            "value": "",
+                            "unit": "mg",
+                            "errorMargin": {
+                                "value": 0.01,
+                                "unit": "mg"
+                            }
+                        },
                         "physicalState": "Liquid",
+                        "concentration": {
+                            "value": "",
+                            "unit": "mol/L"
+                        },
+                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "134",
                             "chemicalName": "Toluene",
@@ -178,7 +191,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": 1,
+                            "value": "1",
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.001,
@@ -186,6 +199,11 @@
                             }
                         },
                         "physicalState": "Liquid",
+                        "concentration": {
+                            "value": "",
+                            "unit": "mol/L"
+                        },
+                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "134",
                             "chemicalName": "4-methoxybenzaldehyde",
@@ -270,7 +288,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": 1,
+                            "value": "1",
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.01,
@@ -278,6 +296,11 @@
                             }
                         },
                         "physicalState": "Liquid",
+                        "concentration": {
+                            "value": "",
+                            "unit": "mol/L"
+                        },
+                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "135",
                             "chemicalName": "Styrene",
@@ -362,7 +385,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": 5,
+                            "value": "5",
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.1,
@@ -370,6 +393,11 @@
                             }
                         },
                         "physicalState": "Liquid",
+                        "concentration": {
+                            "value": "",
+                            "unit": "mol/L"
+                        },
+                        "purity": "",
                         "hasChemical": {
                             "chemicalID": "137",
                             "chemicalName": "4-(Difluoromethyl)benzyl bromide",
@@ -381,7 +409,11 @@
                             "smiles": "BrCc1ccc(cc1)C(F)(F)F",
                             "swissCatNumber": "",
                             "Inchi": "1S/C8H7BrF2/c9-5-6-1-3-7(4-2-6)8(10)11/h1-4,8H,5H2",
-                            "molecularFormula": "C8H7BrF2"
+                            "molecularFormula": "C8H7BrF2",
+                            "density": {
+                                "value": "",
+                                "unit": "g/mL"
+                            }
                         }
                     }
                 ]
@@ -484,7 +516,7 @@
                 }
             },
             "startTime": "2024-07-25T12:03:50",
-            "endingTime": "2024-07-25T12:04:057",
+            "endingTime": "2024-07-25T12:04:05",
             "methodName": "set_pressure",
             "equipmentName": "Chemspeed SWING XL",
             "subEquipmentName": "MTP_Pressure",


### PR DESCRIPTION
This PR corrects the Synth input data.

The data type per field cannot vary: so for observations the expected value should be either `string` or `numeric`, but it cannot be sometimes `"5"` or `""` and other times `2`