### PR TITLE
chore: correct values in measuredQuantity to be numeric not strings

### DIFF
--- a/json-file/1-Synth/1-Synth.json
+++ b/json-file/1-Synth/1-Synth.json
@@ -177,7 +177,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "1",
+                            "value": 1,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.001,
@@ -268,7 +268,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "1",
+                            "value": 1,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.01,
@@ -359,7 +359,7 @@
                             "unit": "mg"
                         },
                         "measuredQuantity": {
-                            "value": "5",
+                            "value": 5,
                             "unit": "mg",
                             "errorMargin": {
                                 "value": 0.1,


### PR DESCRIPTION
This PR corrects values in measuredQuantity that are strings instead of being numeric.